### PR TITLE
ci: add native aarch64 Linux to CI and release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-features
 
+  aarch64:
+    name: aarch64 Linux (native)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check (default features)
+        run: cargo check
+      - name: Check (all features)
+        run: cargo check --all-features
+      - name: Test
+        run: cargo test --all-features
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         rust: [stable]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

`raibid-harness` (incoming DGX-Spark-native harness for coding agents)
targets `aarch64-unknown-linux-gnu` as its primary triple.
`fusabi-host` is a foundational dependency for `harness-skills` and
friends. Today CI runs only on x86_64 Linux / macOS / Windows, so
aarch64 breakage can ship to crates.io unnoticed.

See survey: `/tmp/fusabi-aarch64-survey.md` (maintained by the DevOps
agent that filed this PR).

## What changed

**`.github/workflows/ci.yml`**
- New `aarch64` job running on `ubuntu-24.04-arm` (native ARM runner,
  GA on GitHub-hosted runners). Runs `cargo check`, `cargo check
  --all-features`, and `cargo test --all-features`.

**`.github/workflows/release.yml`**
- Added `ubuntu-24.04-arm` to the `test` matrix so a broken aarch64
  build blocks `cargo publish`.

No binary artifact production here — `fusabi-host` is a library crate
and crates.io distribution is source-only. The value is catching
aarch64 regressions before a release tag is cut.

## Test plan

- [ ] New `aarch64 Linux (native)` CI job passes on this PR.
- [ ] Dispatch `Release` with a pre-release version and confirm the
      new `ubuntu-24.04-arm` matrix leg succeeds.

## Known gaps

- Features `serde-support` and `async-runtime-tokio` are pure Rust; no
  native-dep risk anticipated. If the job reveals otherwise, follow-up
  PR will add the missing system packages to the aarch64 job.

## Status

**Draft** — will be ready-for-review once the aarch64 job has a green
run.